### PR TITLE
Google Daydream V2 Controller

### DIFF
--- a/index.vr.js
+++ b/index.vr.js
@@ -3,7 +3,6 @@ import {
   AppRegistry,
   asset,
   Pano,
-  Text,
   View,
   Video,
   MediaPlayerState,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6756,6 +6756,11 @@
         "prop-types": "15.6.1"
       }
     },
+    "react-vr-controller-raycaster": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/react-vr-controller-raycaster/-/react-vr-controller-raycaster-1.0.0.tgz",
+      "integrity": "sha512-AZzMrgoCYU/oHvXKpkUAIsqQHgSLVjfKyWFWJbt/FH0ZcW1O+kV9Q7hvzeUgGHtkdZrZzE20WgO8bAnJLO//DQ=="
+    },
     "react-vr-web": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-vr-web/-/react-vr-web-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "ovrui": "~2.0.0",
     "react": "16.0.0",
     "react-native": "~0.48.0",
-    "three": "^0.87.0",
     "react-vr": "~2.0.0",
-    "react-vr-web": "~2.0.0"
+    "react-vr-controller-raycaster": "^1.0.0",
+    "react-vr-web": "~2.0.0",
+    "three": "^0.87.0"
   },
   "devDependencies": {
     "babel-jest": "^19.0.0",

--- a/vr/client.js
+++ b/vr/client.js
@@ -4,10 +4,21 @@
 
 // Auto-generated content.
 import {VRInstance} from 'react-vr-web';
+import * as OVRUI from 'ovrui';
+import ControllerRayCaster from 'react-vr-controller-raycaster';
+import * as THREE from 'three'
 
 function init(bundle, parent, options) {
+  const scene = new THREE.Scene();
+  console.log(scene)
   const vr = new VRInstance(bundle, 'FanSourceVR', parent, {
-    // Add custom options here
+    raycasters: [
+      new ControllerRayCaster({scene, color: '#ff0000'}),
+      new OVRUI.MouseRayCaster(),
+    ],
+
+    scene: scene,
+    cursorVisibility: 'visible',
     ...options,
   });
   vr.render = function() {


### PR DESCRIPTION
Google Daydream V2 Controller currently doesn't work. This is an attempt to get it to work but nothing happens so far. I could try to build off what https://github.com/nestoralonso/react-vr-daydream-controller-sample did.